### PR TITLE
Fix saving of intermediate results in fixme.cs

### DIFF
--- a/fixme.cs
+++ b/fixme.cs
@@ -23,9 +23,8 @@ namespace ConsoleApp1
                 return memoized[n];
             }
 
-            // FIXME: Store the result in the dictionary
-            // Create a pull request with the fixed code.
-            return Calculate(n - 1) + Calculate(n - 2);
+            memoized[n] = Calculate(n - 1) + Calculate(n - 2);
+            return memoized[n];
         }
     }
 


### PR DESCRIPTION
Calculated data are saved into dictionary, so they don't have to be calculated more than once.